### PR TITLE
Fix typo causing link to break.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A place for sharing and browsing [Scriptable](https://scriptable.app) scripts an
 
 The project aims to create a place for the community to grow, where people can publish their own creations and find out what others have created: Shareable wants to gather all the scripts that people keep creating and sharing in one, easy-to-use place.
 
-The website is live at [https://shareable.vercel.app/](https//shareable.vercel.app).
+The website is live at [https://shareable.vercel.app/](https://shareable.vercel.app).
 
 ## Bug reporting and feature suggestions
 Any feedback is appreciated. You can either submit an issue or write a message on the [Scriptable Discord server](https://discord.gg/zTDhBta2S5).


### PR DESCRIPTION
Fix missing ':' in url that caused Github to automatically prefix the url with its own url because it thinks it points to a location in the repo, preventing the user from browsing to the website.